### PR TITLE
Add TryBinaryOperator convenience class

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ hs_err_pid*
 # Maven
 log/
 target/
+/bin/

--- a/src/main/java/com/lambdista/example/ParseAndSum.java
+++ b/src/main/java/com/lambdista/example/ParseAndSum.java
@@ -1,0 +1,59 @@
+/**
+ * Copyright 2014 Alessandro Lacava
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.lambdista.example;
+
+import java.util.Arrays;
+
+import com.lambdista.util.Try;
+import com.lambdista.util.TryBinaryOperator;
+
+/**
+ * Parse and sum up integers
+ *
+ * @author Bernhard Frauendienst
+ */
+public class ParseAndSum {
+
+    public static void main(String[] args) {
+
+        System.out.println("Sum using the try-catch block");
+        int sum1 = sumWithoutTry(args);
+        System.out.println("Result: " + sum1);
+
+        System.out.println("Sum using the Try-Success-Failure API");
+        int sum2 = sumWithTry(args);
+        System.out.println("Result: " + sum2);
+    }
+
+    public static int sumWithoutTry(String[] args) {
+        int sum = 0;
+        for (String arg : args) {
+            try {
+                int number = Math.abs(Integer.parseInt(arg));
+                sum += number;
+            } catch (NumberFormatException e) {
+                return -1;
+            }
+        }
+        return sum;
+    }
+
+    public static int sumWithTry(String[] args) {
+        return Arrays.stream(args).map(line -> Try.apply(() -> Math.abs(Integer.parseInt(line))))
+                .reduce(Try.apply(() -> 0), TryBinaryOperator.of(Integer::sum)).getOrElse(-1);
+    }
+
+}

--- a/src/main/java/com/lambdista/util/TryBinaryOperator.java
+++ b/src/main/java/com/lambdista/util/TryBinaryOperator.java
@@ -31,15 +31,7 @@ public interface TryBinaryOperator<T> extends BinaryOperator<Try<T>> {
    */
   public static <T> TryBinaryOperator<T> of(BinaryOperator<T> binaryOperator) {
     Objects.requireNonNull(binaryOperator);
-    return (a, b) -> {
-      if (a.isFailure()) {
-        return a;
-      }
-      if (b.isFailure()) {
-        return b;
-      }
-      return new Try.Success<T>(binaryOperator.apply(a.get(), b.get()));
-    };
+    return (a, b) -> a.flatMap(x -> b.map(y -> binaryOperator.apply(x, y)));
   }
 
   /**

--- a/src/main/java/com/lambdista/util/TryBinaryOperator.java
+++ b/src/main/java/com/lambdista/util/TryBinaryOperator.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2015 Bernhard Frauendienst
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.lambdista.util;
 
 import java.util.Comparator;

--- a/src/main/java/com/lambdista/util/TryBinaryOperator.java
+++ b/src/main/java/com/lambdista/util/TryBinaryOperator.java
@@ -1,0 +1,77 @@
+package com.lambdista.util;
+
+import java.util.Comparator;
+import java.util.Objects;
+import java.util.function.BinaryOperator;
+
+import com.lambdista.util.Try.Failure;
+import com.lambdista.util.Try.Success;
+
+/**
+ * A {@link BinaryOperator} which simplifies working with {@link Try} values, by
+ * returning a {@link Failure} if one of the values is a failure, and passing
+ * the wrapped values to another {@link BinaryOperator} otherwise.
+ * 
+ */
+@FunctionalInterface
+public interface TryBinaryOperator<T> extends BinaryOperator<Try<T>> {
+
+  /**
+   * Returns a {@link TryBinaryOperator} which returns either a {@link Failure},
+   * if either of the both arguments is non-successful, or passes the wrapped
+   * values to the specified {@link BinaryOperator}
+   * 
+   * @param <T> the type of the input arguments of the binaryOperator
+   * @param binaryOperator a {@link BinaryOperator} for operating on the wrapped
+   *          values if both represent a {@link Success}
+   * @return a {@link TryBinaryOperator} which returns a {@link Failure} if
+   *         either of its arguments is a failure, or the result of the binary
+   *         operation done by the passed {@link BinaryOperator}
+   * @throws NullPointerException if the argument is null
+   */
+  public static <T> TryBinaryOperator<T> of(BinaryOperator<T> binaryOperator) {
+    Objects.requireNonNull(binaryOperator);
+    return (a, b) -> {
+      if (a.isFailure()) {
+        return a;
+      }
+      if (b.isFailure()) {
+        return b;
+      }
+      return new Try.Success<T>(binaryOperator.apply(a.get(), b.get()));
+    };
+  }
+
+  /**
+   * Returns a {@link TryBinaryOperator} which returns the lesser of two
+   * elements according to the specified {@code Comparator}, if both values are
+   * a {@link Success}.
+   *
+   * @param <T> the type of the input arguments of the comparator
+   * @param comparator a {@code Comparator} for comparing the two values
+   * @return a {@code TryBinaryOperator} which returns the lesser of its
+   *         operands, according to the supplied {@code Comparator}, or the
+   *         first {@link Failure} if one is encountered.
+   * @throws NullPointerException if the argument is null
+   */
+  public static <T> TryBinaryOperator<T> minBy(Comparator<? super T> comparator) {
+    return TryBinaryOperator.of(BinaryOperator.minBy(comparator));
+  }
+
+  /**
+   * Returns a {@link BinaryOperator} which returns the greater of two elements
+   * according to the specified {@code Comparator}, if both values are a
+   * {@link Success}
+   *
+   * @param <T> the type of the input arguments of the comparator
+   * @param comparator a {@code Comparator} for comparing the two values
+   * @return a {@code TryBinaryOperator} which returns the greater of its
+   *         operands, according to the supplied {@code Comparator}, or the
+   *         first {@link Failure} if one is encountered
+   * @throws NullPointerException if the argument is null
+   */
+  public static <T> TryBinaryOperator<T> maxBy(Comparator<? super T> comparator) {
+    return TryBinaryOperator.of(BinaryOperator.maxBy(comparator));
+  }
+
+}

--- a/src/test/java/com/lambdista/util/TryBinaryOperatorTest.java
+++ b/src/test/java/com/lambdista/util/TryBinaryOperatorTest.java
@@ -1,0 +1,118 @@
+/**
+ * Copyright 2015 Bernhard Frauendienst
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.lambdista.util;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import org.junit.Test;
+
+/**
+ * Unit test for the {@link TryBinaryOperator} API.
+ *
+ * @author Bernhard Frauendienst
+ */
+public class TryBinaryOperatorTest {
+
+    @Test
+    public void testIntegerMinSuccess() {
+        Optional<Try<Integer>> optResult = successNumbers().reduce(TryBinaryOperator.minBy(Comparator.naturalOrder()));
+        assertTrue("result must have a value", optResult.isPresent());
+        Try<Integer> result = optResult.get();
+        assertTrue("result must be a success", result.isSuccess());
+        assertEquals(Integer.valueOf(2), result.get());
+    }
+
+    @Test
+    public void testIntegerMaxSuccess() {
+        Optional<Try<Integer>> optResult = successNumbers().reduce(TryBinaryOperator.maxBy(Comparator.naturalOrder()));
+        assertTrue("result must have a value", optResult.isPresent());
+        Try<Integer> result = optResult.get();
+        assertTrue("result must be a success", result.isSuccess());
+        assertEquals(Integer.valueOf(195), result.get());
+    }
+
+    @Test
+    public void testIntegerSumSuccess() {
+        Optional<Try<Integer>> optResult = successNumbers().reduce(TryBinaryOperator.of(Integer::sum));
+        assertTrue("result must have a value", optResult.isPresent());
+        Try<Integer> result = optResult.get();
+        assertTrue("result must be a success", result.isSuccess());
+        assertEquals(Integer.valueOf(283), result.get());
+    }
+
+    @Test
+    public void testIntegerMinFailure() {
+        Optional<Try<Integer>> optResult = mixedSuccessFailure()
+                .reduce(TryBinaryOperator.minBy(Comparator.naturalOrder()));
+        assertTrue("result must have a value", optResult.isPresent());
+        Try<Integer> result = optResult.get();
+        assertTrue("result must be a failure", result.isFailure());
+    }
+
+    @Test
+    public void testCustomComparatorSuccess() {
+        Optional<Try<String>> optResult = strings().reduce(TryBinaryOperator.minBy(compareCharAt(4)));
+        assertTrue("result must have a value", optResult.isPresent());
+        Try<String> result = optResult.get();
+        assertTrue("result must be a success", result.isSuccess());
+        assertEquals("foobar", result.get());
+    }
+
+    @Test
+    public void testCustomComparatorFailure() {
+        // "dummy" is shorted than 6 characters, the comparator will throw a StringIndexOutOfBoundsException
+        Optional<Try<String>> optResult = strings().reduce(TryBinaryOperator.minBy(compareCharAt(5)));
+        assertTrue("result must have a value", optResult.isPresent());
+        Try<String> result = optResult.get();
+        assertTrue("result must be a failure", result.isFailure());
+        assertTrue("exception must be a StringIndexOutOfBoundsException",
+                result.failed().get() instanceof StringIndexOutOfBoundsException);
+    }
+
+    /* helper methods */
+
+    private Stream<Try<String>> strings() {
+        return Arrays.asList("abcdefgh", "foobar", "dummy", "sample").stream().map(this::success);
+    }
+
+    private Stream<Try<Integer>> successNumbers() {
+        return Arrays.asList(42, 5, 23, 16, 195, 2).stream().map(this::success);
+    }
+
+    private Stream<Try<Integer>> mixedSuccessFailure() {
+        return Arrays.asList(success(1), success(2), failure(), success(3)).stream();
+    }
+
+    private Comparator<String> compareCharAt(int index) {
+        return (a, b) -> Character.compare(a.charAt(index), b.charAt(index));
+    }
+
+    private <T> Try<T> success(T o) {
+        return Try.apply(() -> o);
+    }
+
+    private Try<Integer> failure() {
+        return Try.apply(() -> {
+            throw new NumberFormatException("Number not valid");
+        });
+    }
+}


### PR DESCRIPTION
I propose to add a BinaryOperator helper which simplifies working with BinaryOperators of Try values, e.g. when reducing a stream of Try values.

Note that the implementation of `of()` could also be written as
```java
(a, b) -> a.flatMap(x -> b.map(y -> binaryOperator.apply(x, y)))
```
but I opted to keep the code more readable.

Given a class that has a method `Instant getModifiedOn() throws IOException`, a common usage example could look like this:

```java
files.stream()
    .map(c -> Try.apply(c::getModifiedOn))
    .reduce(new Try.Success<>(Instant.MIN),
        TryBinaryOperator.maxBy(Comparator.naturalOrder()));
```