### PR TITLE
Added support for try-with-resources

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,13 +38,20 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     </properties>
 
-    <dependencies>
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.11</version>
-        </dependency>
-    </dependencies>
+	<dependencies>
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<version>4.11</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-all</artifactId>
+			<version>1.10.19</version>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
 
     <build>
         <plugins>

--- a/src/main/java/com/lambdista/example/ReadInputStreamAsString.java
+++ b/src/main/java/com/lambdista/example/ReadInputStreamAsString.java
@@ -1,0 +1,81 @@
+/**
+ * Copyright 2014 Alessandro Lacava
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.lambdista.example;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Random;
+
+import com.lambdista.util.Try;
+
+/**
+ * Try-with-resource input stream consumption
+ *
+ * @author Gregor Trefs 
+ */
+public class ReadInputStreamAsString { 
+
+    public static void main(String[] args) throws IOException {
+    	final InputStream stream = createByteArrayInputStream(50);
+    	markStartOfStream(stream);
+    	
+        System.out.println("Read InputStream as String using the try-catch block");
+        final String result1 = consumptionWithoutTry(stream);
+        System.out.println("Result: " + result1);
+
+        resetStreamToStart(stream);
+        
+        System.out.println("Read InputStream as String using the Try-Success-Failure API");
+        final String result2 = consumptionWithTry(stream);
+        System.out.println("Result: " + result2);
+    }
+
+	private static void markStartOfStream(final InputStream stream) {
+		stream.mark(100);
+	}
+
+	private static void resetStreamToStart(final InputStream stream) throws IOException {
+		stream.reset();
+	}
+    
+    private static InputStream createByteArrayInputStream(int numberOfRandomBytes){
+    	final byte[] randomBytes = new byte[numberOfRandomBytes];
+    	new Random().nextBytes(randomBytes);
+    	return new ByteArrayInputStream(randomBytes);
+    }
+
+    private static String consumptionWithoutTry(InputStream stream) {
+    	try(InputStream in = stream){
+    		return convertStreamToString(in);
+    	} catch (IOException e) {
+			return "";
+		}    
+    }
+
+    private static String consumptionWithTry(InputStream stream) {
+        return Try.apply(ReadInputStreamAsString::convertStreamToString).apply(stream).get();
+    }
+    
+	// http://stackoverflow.com/questions/309424/read-convert-an-inputstream-to-a-string
+	@SuppressWarnings("resource")
+	private static String convertStreamToString(java.io.InputStream is) {
+		try (java.util.Scanner s = new java.util.Scanner(is).useDelimiter("\\A")) {
+			return s.hasNext() ? s.next() : "";
+		}
+	}
+
+}

--- a/src/main/java/com/lambdista/util/Try.java
+++ b/src/main/java/com/lambdista/util/Try.java
@@ -197,6 +197,28 @@ public abstract class Try<T> {
     public abstract <U> Try<U> transform(Function<? super T, ? extends Try<U>> successFunc,
                                          Function<Exception, ? extends Try<U>> failureFunc);
 
+	/**
+	 * Converts a {@link Function} expecting an {@link AutoClosable} into a
+	 * {@code Function} which closes the {@code AutoCloseable} after execution.
+	 * 
+	 * <p>
+	 * This is equivalent to the <a href=
+	 * "https://docs.oracle.com/javase/tutorial/essential/exceptions/tryResourceClose.html"
+	 * > try-with-resources</a> statement.
+	 * 
+	 * @param consumer {@code Function} expecting an {@code AutoCloseable}
+	 * @return a {@code Function} closing its {@code AutoCloseable} parameter and 
+	 * wrapping the outcome as a {@code Try}
+	 * @see #apply(FailableSupplier)
+	 */
+    public static <T extends AutoCloseable,R> Function<T, Try<R>> apply(Function<T, R> consumer) {
+		return closeable -> Try.apply(() -> {
+				try (T in = closeable) {
+					return consumer.apply(in);
+				}
+			});
+	}
+    
     /**
      * Constructs a {@code Try} using the {@link FailableSupplier} parameter. This
      * method will ensure any non-fatal exception is caught and a {@link Failure} object is returned.


### PR DESCRIPTION
Since Java 7 there is an advanced syntax to automatically close
`AutoCloseable` types, namely `try-with-resources statement`. This
commit adds the ability to convert functions which consume an
`AutoClosable` into functions which automatically close the
`AutoCloseable` after exuction. Further, the return type is wrapped in a
`Try`. Hence, this commit enables the `Try` type to act like the
`try-with-resources statment` and automatically close `AutoCloseable`s.

Issue: #6 